### PR TITLE
PlatformIO: initial support for building firmware with pio

### DIFF
--- a/FatFs/README.md
+++ b/FatFs/README.md
@@ -2,7 +2,7 @@
 
 Download the FatFs source code from [www.elm-chan.org](http://www.elm-chan.org/fsw/ff/00index_e.html) and unpack to this directory.
 
-Delete the skeleton `discio.c` driver file in the FatFs folder and edit `ffconf.h` as follows:
+Delete the skeleton `diskio.c` driver file in the FatFs folder and edit `ffconf.h` as follows:
 
 Set `FF_FS_READONLY` to `1`.
 
@@ -12,7 +12,7 @@ Set `FF_USE_LFN` to `1` or another suitable value.
 
 Other options may be edited as well depending on your needs.
 
-__NOTE:__ The `discio.c` implementation provided as part of this driver has been tested with FatFs `R0.13c`.
+__NOTE:__ The `diskio.c` implementation provided as part of this driver has been tested with FatFs `R0.13c`.
 
 __NOTE:__ I have tested with a 10K pullup connected to `MOSI (PB5)`, not sure if it is really needed...
 

--- a/STM32F103RCTX_FLASH.ld
+++ b/STM32F103RCTX_FLASH.ld
@@ -33,11 +33,14 @@ _estack = ORIGIN(RAM) + LENGTH(RAM);    /* end of "RAM" Ram type memory */
 _Min_Heap_Size = 0x2000; /* required amount of heap  */
 _Min_Stack_Size = 0x400;    /* required amount of stack */
 
+/* Dummy symbol we can override using -Wl,--defsym on the command line */
+LD_VECT_TAB_OFFSET = DEFINED(LD_VECT_TAB_OFFSET)? LD_VECT_TAB_OFFSET : 0;
+
 /* Memories definition */
 MEMORY
 {
-  RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 48K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 256K
+    RAM        (xrw)   : ORIGIN = 0x20000000,                     LENGTH = 48K
+    FLASH      (rx)    : ORIGIN = 0x8000000+LD_VECT_TAB_OFFSET,   LENGTH = 256K-LD_VECT_TAB_OFFSET
 }
 
 /* Sections */

--- a/Src/btt_skr_mini_e3_2.0.c
+++ b/Src/btt_skr_mini_e3_2.0.c
@@ -75,6 +75,19 @@ void tmc_uart_write (trinamic_motor_t driver, TMC_uart_write_datagram_t *dgr)
     while(tmc_uart.get_tx_buffer_count());	// Wait while the datagram is delivered
 }
 
+static void btt_skr_mini_e3_enable_usb(void) {
+#if USB_SERIAL_CDC
+    /* PA14 must be set low to enable USB D+ */
+    GPIO_InitTypeDef GPIO_Init = {
+        .Mode = GPIO_MODE_OUTPUT_PP,
+        .Pin = GPIO_PIN_14,
+        .Speed = GPIO_SPEED_FREQ_LOW,
+    };
+    HAL_GPIO_Init(GPIOA, &GPIO_Init);
+    HAL_GPIO_WritePin(GPIOA, GPIO_PIN_14, GPIO_PIN_RESET);
+#endif
+}
+
 void board_init (void)
 {
 #ifdef SERIAL2_MOD
@@ -83,6 +96,7 @@ void board_init (void)
     memcpy(&tmc_uart, serialInit(), sizeof(io_stream_t));
 #endif
     tmc_uart.set_enqueue_rt_handler(stream_buffer_all);
+    btt_skr_mini_e3_enable_usb();
 }
 
 #endif

--- a/Src/diskio.c
+++ b/Src/diskio.c
@@ -461,7 +461,7 @@ DRESULT disk_read (
     BYTE drv,            /* Physical drive nmuber (0) */
     BYTE *buff,            /* Pointer to the data buffer to store read data */
     DWORD sector,        /* Start sector number (LBA) */
-    BYTE count            /* Sector count (1..255) */
+    UINT count            /* Sector count (1..255) */
 )
 {
     if (drv || !count) return RES_PARERR;
@@ -505,7 +505,7 @@ DRESULT disk_write (
     BYTE drv,            /* Physical drive nmuber (0) */
     const BYTE *buff,    /* Pointer to the data to be written */
     DWORD sector,        /* Start sector number (LBA) */
-    BYTE count            /* Sector count (1..255) */
+    UINT count           /* Sector count (1..255) */
 )
 {
     if (drv || !count) return RES_PARERR;

--- a/Src/driver.c
+++ b/Src/driver.c
@@ -204,6 +204,7 @@ static bool irq_claim (irq_type_t irq, uint_fast8_t id, irq_callback_ptr handler
 
 #endif
 
+void disk_timerproc (void);
 static void spindle_set_speed (uint_fast16_t pwm_value);
 
 static void driver_delay (uint32_t ms, void (*callback)(void))


### PR DESCRIPTION
In response to #4, this provides four target environments:

- SKR Mini E3 V2.0 one with 3.3V serial
- dito but with USB serial
- Bluepill F103C8 (128k), as used in CNC3040, with 3.3V serial
- dito but with USB serial

To test this out, install PlatformIO core:

- https://docs.platformio.org/en/latest/core/installation.html

Example:
    
    # Build all target environments
    pio run 
    # Build a single target environments
    pio run -e BTT_SKR_MINI_E3_V20_USB
    # Copy the relevant target's firmware to an SD card mounted at /mnt
    sudo cp .pio/build/BTT_SKR_MINI_E3_V20_USB/firmware.bin /mnt
    # Unmount the SD card, place it in the board and let the built-in boot loader flash it

I've only tested the BTT SKR Mini E3 environments.  I haven't synced the build flags that may or may not be present in the `.cproject` file created by the original IDE.

Please note that I've disabled `USB_SERIAL_CDC` by default in order to be able to override this value from `platformio.ini`.  If you want that to be enabled by default, perhaps this can be configured as a C/C++ define in the IDE?

I also made an update to a submodule (synced with upstream) and added code to the BTT SKR Mini E3 `board_init()` to set PA14 low to get USB serial working on this board.

Additional boards can be added by duplicating an existing environment and adjusting:

- `board` (find an existing one on https://docs.platformio.org/en/latest/platforms/ststm32.html#boards and use the value from the board-specific page)
- `board_build.ldscript`
- `build_flags`
- `lib_deps`

In the future, automated build tests may be implemented using GitHub Actions -- see https://docs.platformio.org/en/latest/integration/ci/github-actions.html

Let me know what you think.